### PR TITLE
Preserve redirect_uri casing

### DIFF
--- a/routes/oauth/authorize.dart
+++ b/routes/oauth/authorize.dart
@@ -62,10 +62,7 @@ Future<Response> _get(RequestContext context) async {
 // Uri.toString() lowercases the host, which breaks the URI
 // This is just a simple function that preserves the casing
 String stringifyModifiedUri(Uri uri, String originalUri) {
-  if (uri.path.isEmpty) return originalUri;
-
-  final host = originalUri.split(uri.path)[0];
-
+  final host = originalUri.substring(0, uri.scheme.length + uri.host.length + 3);
   return host + uri.toString().substring(host.length);
 }
 

--- a/routes/oauth/authorize.dart
+++ b/routes/oauth/authorize.dart
@@ -137,7 +137,7 @@ Future<Response> _post(RequestContext context) async {
     statusCode: HttpStatus.found,
     headers: {
       HttpHeaders.locationHeader:
-          stringifyModifiedURI(redirectUriWithCode, auth.redirectUri),
+          stringifyModifiedUri(redirectUriWithCode, auth.redirectUri),
     },
   );
 }

--- a/routes/oauth/authorize.dart
+++ b/routes/oauth/authorize.dart
@@ -59,6 +59,16 @@ Future<Response> _get(RequestContext context) async {
   );
 }
 
+// Uri.toString() lowercases the host, which breaks the URI
+// This is just a simple function that preserves the casing
+String stringifyModifiedUri(Uri uri, String originalUri) {
+  if (uri.path.isEmpty) return originalUri;
+
+  final host = originalUri.split(uri.path)[0];
+
+  return host + uri.toString().substring(host.length);
+}
+
 /// Get sign-in information entered into the form by the user and process
 /// it to redirect with an auth token code.
 /// POST /oauth/authorize HTTP/1.1
@@ -126,7 +136,8 @@ Future<Response> _post(RequestContext context) async {
   return Response(
     statusCode: HttpStatus.found,
     headers: {
-      HttpHeaders.locationHeader: redirectUriWithCode.toString(),
+      HttpHeaders.locationHeader:
+          stringifyModifiedURI(redirectUriWithCode, auth.redirectUri),
     },
   );
 }


### PR DESCRIPTION
This pr fixes #13 by adding a function that restores URI casing when stringifying.