### PR TITLE
timeline backfilling/pagination support

### DIFF
--- a/lib/models/params/timeline_params.dart
+++ b/lib/models/params/timeline_params.dart
@@ -1,0 +1,38 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'timeline_params.g.dart';
+
+/// Parameters for retrieving posts on a timeline.
+@JsonSerializable()
+class TimelineParams {
+  /// Constructs an instance of [TimelineParams].
+  TimelineParams({
+    this.maxId,
+    this.sinceId,
+    this.minId,
+    this.limit = 20,
+  });
+
+  /// Converts JSON into a [TimelineParams] instance.
+  factory TimelineParams.fromJson(Map<String, dynamic> json) =>
+      _$TimelineParamsFromJson(json);
+
+  /// Converts the [TimelineParams] to JSON.
+  Map<String, dynamic> toJson() => _$TimelineParamsToJson(this);
+
+  /// Return results older than this ID.
+  @JsonKey(name: 'max_id')
+  final String? maxId;
+
+  /// Return results newer than this ID.
+  @JsonKey(name: 'since_id')
+  final String? sinceId;
+
+  /// Return results immediately newer than this ID.
+  @JsonKey(name: 'min_id')
+  final String? minId;
+
+  /// The maximum number of results to return.
+  @JsonKey(fromJson: int.parse)
+  final int limit;
+}

--- a/lib/models/params/timeline_params.dart
+++ b/lib/models/params/timeline_params.dart
@@ -7,6 +7,7 @@ part 'timeline_params.g.dart';
 class TimelineParams {
   /// Constructs an instance of [TimelineParams].
   TimelineParams({
+    this.cursor,
     this.maxId,
     this.sinceId,
     this.minId,
@@ -35,4 +36,12 @@ class TimelineParams {
   /// The maximum number of results to return.
   @JsonKey(fromJson: int.parse)
   final int limit;
+
+  /// Arbitrary cursor string. This is not present in the Mastodon API, and
+  /// is only used by SkyBridge to make pagination easier.
+  final String? cursor;
+
+  /// Whether or not this request contains *only* a [minId], signifying that
+  /// it's a request to fetch new posts after a certain point.
+  bool get isNewPostsRequest => minId != null && maxId == null && sinceId == null && cursor == null;
 }

--- a/lib/models/params/timeline_params.g.dart
+++ b/lib/models/params/timeline_params.g.dart
@@ -8,6 +8,7 @@ part of 'timeline_params.dart';
 
 TimelineParams _$TimelineParamsFromJson(Map<String, dynamic> json) =>
     TimelineParams(
+      cursor: json['cursor'] as String?,
       maxId: json['max_id'] as String?,
       sinceId: json['since_id'] as String?,
       minId: json['min_id'] as String?,
@@ -20,4 +21,5 @@ Map<String, dynamic> _$TimelineParamsToJson(TimelineParams instance) =>
       'since_id': instance.sinceId,
       'min_id': instance.minId,
       'limit': instance.limit,
+      'cursor': instance.cursor,
     };

--- a/lib/models/params/timeline_params.g.dart
+++ b/lib/models/params/timeline_params.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'timeline_params.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+TimelineParams _$TimelineParamsFromJson(Map<String, dynamic> json) =>
+    TimelineParams(
+      maxId: json['max_id'] as String?,
+      sinceId: json['since_id'] as String?,
+      minId: json['min_id'] as String?,
+      limit: json['limit'] == null ? 20 : int.parse(json['limit'] as String),
+    );
+
+Map<String, dynamic> _$TimelineParamsToJson(TimelineParams instance) =>
+    <String, dynamic>{
+      'max_id': instance.maxId,
+      'since_id': instance.sinceId,
+      'min_id': instance.minId,
+      'limit': instance.limit,
+    };

--- a/routes/api/v1/timelines/home.dart
+++ b/routes/api/v1/timelines/home.dart
@@ -2,27 +2,101 @@ import 'package:dart_frog/dart_frog.dart';
 import 'package:sky_bridge/auth.dart';
 import 'package:sky_bridge/database.dart';
 import 'package:sky_bridge/models/mastodon/mastodon_post.dart';
+import 'package:sky_bridge/models/params/timeline_params.dart';
 import 'package:sky_bridge/util.dart';
 
 Future<Response> onRequest(RequestContext context) async {
+  final params = context.request.uri.queryParameters;
+  final encodedParams = TimelineParams.fromJson(params);
+
   // Get a bluesky connection/session from the a provided bearer token.
   // If the token is invalid, bail out and return an error.
   final bluesky = await blueskyFromContext(context);
   if (bluesky == null) return authError();
 
-  final feed = await bluesky.feeds.findTimeline(limit: 40);
+  final List<MastodonPost> allPosts;
+  var nextCursor;
 
-  // Take all the posts and convert them to Mastodon ones
-  // Await all the futures, getting any necessary data from the database.
-  final posts = await db.writeTxn(() async {
-    final futures = feed.data.feed.map(MastodonPost.fromFeedView).toList();
-    return Future.wait(futures);
-  });
+  if (encodedParams.minId != null && encodedParams.maxId == null && encodedParams.sinceId == null) {
+    // Get all the posts following minId so that Ivory can backfill its timeline
+    allPosts = [];
+
+    final lastRead = BigInt.parse(encodedParams.minId!);
+    BigInt? maxID;
+    String? prevCursor;
+    var done = false;
+
+    while (!done) {
+      final feed = await bluesky.feeds.findTimeline(limit: 50, cursor: prevCursor);
+      final posts = await db.writeTxn(() async {
+        final futures = feed.data.feed.map(MastodonPost.fromFeedView).toList();
+        return Future.wait(futures);
+      });
+
+      for (final post in posts) {
+        final id = BigInt.parse(post.id);
+        if (id <= lastRead) {
+          // We've seen the last-read post (or something older than that).
+          // That means we're fully caught up with the supplied min_id
+          done = true;
+          break;
+        }
+
+        if (maxID == null || id < maxID) {
+          maxID = id - BigInt.one;
+        }
+
+        allPosts.add(post);
+      }
+
+      print('Loaded ${posts.length} posts (total ${allPosts.length}, new maxID=$maxID)');
+      prevCursor = feed.data.cursor;
+
+      if (posts.length < 25) {
+        // Bail early and don't try to fetch more posts if the batch was tiny
+        done = true;
+      }
+    }
+
+    nextCursor = prevCursor;
+  } else {
+    // Make a single, standard request
+    final feed = await bluesky.feeds.findTimeline(limit: encodedParams.limit);
+    allPosts = await db.writeTxn(() async {
+      final futures = feed.data.feed.map(MastodonPost.fromFeedView).toList();
+      return Future.wait(futures);
+    });
+    nextCursor = feed.data.cursor;
+  }
 
   // Get the parent posts for each post.
-  final processedPosts = await processParentPosts(bluesky, posts);
+  final processedPosts = await processParentPosts(bluesky, allPosts);
+
+  final headers = <String, Object>{};
+  if (processedPosts.isNotEmpty) {
+    final uri = context.request.uri;
+
+    var lowestID = BigInt.parse('99999999999999999999');
+    var highestID = BigInt.from(0);
+    for (final post in processedPosts) {
+      final id = BigInt.parse(post.id);
+      if (id < lowestID) {
+        lowestID = id;
+      }
+      if (id > highestID) {
+        highestID = id;
+      }
+    }
+
+    final prevParams = {'min_id': highestID.toString()};
+    final nextParams = {'max_id': (lowestID - BigInt.one).toString()};
+    final prevURI = uri.replace(queryParameters: prevParams);
+    final nextURI = uri.replace(queryParameters: nextParams);
+    headers['Link'] = '<$prevURI>; rel="prev", <$nextURI>; rel="next"';
+  }
 
   return threadedJsonResponse(
     body: processedPosts,
+    headers: headers
   );
 }


### PR DESCRIPTION
This is a first draft of support for backfilling and paginating timelines so that viewing ~~tweets~~ ~~toots~~ ~~posts~~ skeets in Ivory is a more comfortable experience.

---

Requests to the home timeline with a `min_id` specified (and no `max_id` or `since_id`) are treated as _"I want the latest posts"_, and it tries to fetch as many as possible and deliver them in one request, using the same logic that I wrote for BirdBridge (https://github.com/Treeki/BirdBridge/blob/main/main.ts#L129-L207).

I also generate a Link header to make Ivory happy - this gets rid of the issue where it's perpetually stuck in a loading state and won't allow you to manually refresh or show the amount of unread posts.

---

What's still missing:

- Support for this same system on other timelines - it should work for custom timelines, for users' own timelines, and probably also for notifications
- ~~The ability to go _back_ in time: it serves a `rel="next"` link with a `max_id` field which in theory should work, but Skybridge won't use it yet~~

---

~~Using the 'next' links is tricky because Bluesky requires cursors.~~

~~In theory you could ignore `max_id` and just supply the cursor as a non-standard parameter in the `rel="next"` link, but I haven't tested if this will work with Ivory.~~

~~I know that `rel="prev"` links definitely need to follow the standard format for Ivory to work correctly (as it will try to generate its own in certain cases, based off its newest known post ID) but I don't _think_ they do the same for `rel="prev"`. It's probably worth a try at least!~~

Tried this and it works, so that technique seems viable - I can now scroll further down in the timeline!