### PR TITLE
bump up the version `bluesky_text`

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -101,18 +101,18 @@ packages:
     dependency: "direct main"
     description:
       name: bluesky
-      sha256: badda9daa9f16af63a54592718ff5ba798253df883f10267733eec662fc342ff
+      sha256: "514f7b5cff1117d19e205a95f36b9771caf0b7fe9961a48b006e5762de7d3f3a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.5"
+    version: "0.8.11"
   bluesky_text:
     dependency: "direct main"
     description:
       name: bluesky_text
-      sha256: "3aca452fb7a37782564ce0a89b81fa37195303178cd1170ac66a21a1e8035005"
+      sha256: "189800c6e7e75c0424cca40099b7492d6bb0493c6225a4eb46805aad5a7ec95a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.1"
+    version: "0.4.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -489,6 +489,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  icann_tlds:
+    dependency: transitive
+    description:
+      name: icann_tlds
+      sha256: c94080902bec5a863ef6fecf5a490d18496a4b4584959fe9933c492a0673b00d
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   ieee754:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 
 dependencies:
   atproto: ^0.6.4
-  bluesky: ^0.8.5
-  bluesky_text: ^0.3.1
+  bluesky: ^0.8.11
+  bluesky_text: ^0.4.0
   collection: ^1.17.1
   copy_with_extension: ^5.0.2
   crypto: ^3.0.2


### PR DESCRIPTION
Hi

BlueskyText algorithm has been improved to detect abbreviated URLs such as `bsky.app` as facets. 

Also the domains of handles and URLs will also be verified based on the ICANN TLD list, and invalid domains will be excluded from facet. There are no changes to the interface.