### PR TITLE
bump the version `bluesky_text`

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -109,10 +109,10 @@ packages:
     dependency: "direct main"
     description:
       name: bluesky_text
-      sha256: "189800c6e7e75c0424cca40099b7492d6bb0493c6225a4eb46805aad5a7ec95a"
+      sha256: "5bc3dc50f7907bc7ba4729bea72c2ffbb4cc3d19a78629dfafd029492e62c384"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0"
+    version: "0.4.1"
   boolean_selector:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   atproto: ^0.6.4
   bluesky: ^0.8.11
-  bluesky_text: ^0.4.0
+  bluesky_text: ^0.4.1
   collection: ^1.17.1
   copy_with_extension: ^5.0.2
   crypto: ^3.0.2


### PR DESCRIPTION
Hi

There was a bug in `bluesky_text` with URL detection. Please use `v0.4.1` which fixes this bug.