### PR TITLE
Skip original post in `traverseReplies` result

### DIFF
--- a/lib/util.dart
+++ b/lib/util.dart
@@ -132,7 +132,8 @@ Future<List<MastodonPost>> traverseReplies(
     record: (record) async {
       // Get the current depth post and add it to the list.
       final currentPost = await MastodonPost.fromBlueSkyPost(record.data.post);
-      result.add(currentPost);
+      // Skip the first post.
+      if (depth > 0) result.add(currentPost);
 
       // We don't want to traverse too deep, 6 is just a number I pulled out
       // of thin air. Need to look into how deep Bluesky goes.


### PR DESCRIPTION
I just copied this from `traverseParents`, comment and all, but it should do the trick.

Including a post as its own reply seems to confuse some Mastodon clients. See also/fixes #50.