### PR TITLE
Migrate `atproto` and `bluesky`

### DIFF
--- a/lib/models/mastodon/mastodon_notification.dart
+++ b/lib/models/mastodon/mastodon_notification.dart
@@ -83,7 +83,7 @@ class MastodonNotification {
     final posts = await chunkResults<bsky.Post, bsky.AtUri>(
       items: postUris,
       callback: (chunk) async {
-        final response = await bluesky.feeds.findPosts(uris: chunk);
+        final response = await bluesky.feed.getPosts(uris: chunk);
         return response.data.posts;
       },
     );

--- a/lib/models/mastodon/mastodon_post.dart
+++ b/lib/models/mastodon/mastodon_post.dart
@@ -315,7 +315,7 @@ class MastodonPost {
       final createdAt = DateTime.now().toUtc();
 
       // Create the appropriate bluesky record.
-      await bluesky.repositories.createRecord(
+      await bluesky.repo.createRecord(
         collection: at.NSID.create('feed.bsky.app', 'repost'),
         record: {
           'subject': {
@@ -516,7 +516,7 @@ Future<List<MastodonPost>> processParentPosts(
   final results = await chunkResults<bsky.Post, bsky.AtUri>(
     items: uris,
     callback: (chunk) async {
-      final response = await bluesky.feeds.findPosts(uris: chunk);
+      final response = await bluesky.feed.getPosts(uris: chunk);
       return response.data.posts;
     },
   );

--- a/lib/models/mastodon/mastodon_relationship.dart
+++ b/lib/models/mastodon/mastodon_relationship.dart
@@ -40,7 +40,7 @@ class MastodonRelationship {
   ) async {
     // Get the profile for the account and check the relationship with the
     // current user.
-    final profile = await bluesky.actors.findProfile(actor: account.did);
+    final profile = await bluesky.actor.getProfile(actor: account.did);
     final blocking = profile.data.viewer.blocking != null;
     final blockedBy = profile.data.viewer.isBlockedBy;
     final muting = profile.data.viewer.isMuted;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -61,34 +61,34 @@ packages:
     dependency: transitive
     description:
       name: at_identifier
-      sha256: "128cfdc95a877973e3349845589f974043ca4c3ce55726e9b530ab866f39bc18"
+      sha256: "3f17d5efab5e34d4b6cfe357d5e97558536ca19892951dedd821e01b0c8d33f6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.1"
   at_uri:
     dependency: transitive
     description:
       name: at_uri
-      sha256: "0a10c6b18c3deecd81ece36964ee698ee9ba3f8a07c870b2c9a0a76e432e8f7f"
+      sha256: c708205d126e1d3356f8c75a1548522f49b26c2b2eaa95b5cfc011d2444604a4
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.2"
+    version: "0.2.3"
   atproto:
     dependency: "direct main"
     description:
       name: atproto
-      sha256: "0a63e174846decc26555d932d80135ad86c49b14c50518cab8d7b12618193a0e"
+      sha256: "015af8457bd1ae08d3b99bcddbead971f8722ad7abb5ddafeb5acfe5602b548b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.0"
+    version: "0.11.0"
   atproto_core:
     dependency: transitive
     description:
       name: atproto_core
-      sha256: "417abb0897ddb2053ff2aad9c17ea861148c2e637c311410d95ad4cc888ed58d"
+      sha256: c25c7c4fe163f5dd206ce53f890d3805429ca3135d27ae490b9979a2bfe217df
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.3"
+    version: "0.9.0"
   base_codecs:
     dependency: transitive
     description:
@@ -101,18 +101,18 @@ packages:
     dependency: "direct main"
     description:
       name: bluesky
-      sha256: "49ed5ff7dd6b6b672b59f3bb5fce7cf17a8fffeb16390a8eddff7b561979ee49"
+      sha256: "77df53a9dc5e74ea5b30d3d2b6f7d93a05b0899aaa2efc7a19455d9c3570547c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.1"
+    version: "0.15.1"
   bluesky_text:
     dependency: "direct main"
     description:
       name: bluesky_text
-      sha256: "1b40bc6f768f5fb4c64abe68edbc50fbef41ecbbc2910b91d9f74b9ff6c6e40a"
+      sha256: "0ff7bfe120fbe9004cbc9dac12cf8600e34e72ed973bec95ff1039e19081485e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.2"
+    version: "0.6.4"
   boolean_selector:
     dependency: transitive
     description:
@@ -653,10 +653,10 @@ packages:
     dependency: transitive
     description:
       name: multiformats
-      sha256: c3c6bb1be062333eff159f1d04fc3a1ed02c89a58d0fdaf59daaa8b7a6fd9e81
+      sha256: ccaa1d4aa5bd57f1d132fc955ef2fd259e4115a80a10b4ce525c2b3d3ddfc260
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   node_preamble:
     dependency: transitive
     description:
@@ -669,10 +669,10 @@ packages:
     dependency: transitive
     description:
       name: nsid
-      sha256: "65240e4cc13c1d1c096c65bffd8259998ea1dc46a8820150117b1a66baea6324"
+      sha256: c03f59aa01eb8bc0dd5e4575b51bb45b276214a1bc36b49029830a4950aaad20
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.1"
+    version: "0.3.0"
   orm:
     dependency: "direct main"
     description:
@@ -1053,10 +1053,10 @@ packages:
     dependency: transitive
     description:
       name: xrpc
-      sha256: "03c2cecea7d1c8ac8b2548432fb9c4ef8a130f316479cf13ca042ba552f4ecde"
+      sha256: a94544be95d5948c60304b4493d89f65dd88cb5c9ee7aabdeebcc23c192a20f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.1"
+    version: "0.4.3"
   xxh3:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,9 +7,9 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  atproto: ^0.9.0
-  bluesky: ^0.13.1
-  bluesky_text: ^0.6.2
+  atproto: ^0.11.0
+  bluesky: ^0.15.1
+  bluesky_text: ^0.6.4
   collection: ^1.17.1
   copy_with_extension: ^5.0.2
   crypto: ^3.0.2

--- a/routes/api/v1/accounts/[id]/follow.dart
+++ b/routes/api/v1/accounts/[id]/follow.dart
@@ -38,11 +38,11 @@ Future<Response> onRequest<T>(RequestContext context, String id) async {
   if (did == null) Response(statusCode: HttpStatus.notFound);
 
   // Check if we're already following the account.
-  final profile = await bluesky.actors.findProfile(actor: did!);
+  final profile = await bluesky.actor.getProfile(actor: did!);
   final alreadyFollowing = profile.data.viewer.following != null;
 
   // If we're not following the account, create a follow record.
-  if (!alreadyFollowing) await bluesky.graphs.createFollow(did: did);
+  if (!alreadyFollowing) await bluesky.graph.follow(did: did);
 
   final rel = await MastodonRelationship.getActorRelationship(bluesky, record!);
 

--- a/routes/api/v1/accounts/[id]/followers.dart
+++ b/routes/api/v1/accounts/[id]/followers.dart
@@ -25,7 +25,7 @@ Future<Response> onRequest(RequestContext context, String id) async {
   );
   if (userRecord == null) return Response(statusCode: HttpStatus.notFound);
 
-  final response = await bluesky.graphs.findFollowers(actor: userRecord.did);
+  final response = await bluesky.graph.getFollowers(actor: userRecord.did);
 
   // Get all the handles from the results and grab the full profile info.
   final handles = response.data.followers.map((actor) => actor.handle).toList();
@@ -35,7 +35,7 @@ Future<Response> onRequest(RequestContext context, String id) async {
   final profiles = await chunkResults<bsky.ActorProfile, String>(
     items: handles,
     callback: (chunk) async {
-      final response = await bluesky.actors.findProfiles(actors: chunk);
+      final response = await bluesky.actor.getProfiles(actors: chunk);
       return response.data.profiles;
     },
   );

--- a/routes/api/v1/accounts/[id]/following.dart
+++ b/routes/api/v1/accounts/[id]/following.dart
@@ -25,7 +25,7 @@ Future<Response> onRequest(RequestContext context, String id) async {
   );
   if (userRecord == null) return Response(statusCode: HttpStatus.notFound);
 
-  final response = await bluesky.graphs.findFollows(actor: userRecord.did);
+  final response = await bluesky.graph.getFollows(actor: userRecord.did);
 
   // Get all the handles from the results and grab the full profile info.
   final handles = response.data.follows.map((actor) => actor.handle).toList();
@@ -35,7 +35,7 @@ Future<Response> onRequest(RequestContext context, String id) async {
   final profiles = await chunkResults<bsky.ActorProfile, String>(
     items: handles,
     callback: (chunk) async {
-      final response = await bluesky.actors.findProfiles(actors: chunk);
+      final response = await bluesky.actor.getProfiles(actors: chunk);
       return response.data.profiles;
     },
   );

--- a/routes/api/v1/accounts/[id]/index.dart
+++ b/routes/api/v1/accounts/[id]/index.dart
@@ -26,7 +26,7 @@ Future<Response> onRequest<T>(RequestContext context, String id) async {
     return Response(statusCode: HttpStatus.notFound);
   }
 
-  final profile = await bluesky.actors.findProfile(actor: user.did);
+  final profile = await bluesky.actor.getProfile(actor: user.did);
 
   final account = await databaseTransaction(
     () => MastodonAccount.fromActorProfile(profile.data),

--- a/routes/api/v1/accounts/[id]/statuses.dart
+++ b/routes/api/v1/accounts/[id]/statuses.dart
@@ -36,7 +36,7 @@ Future<Response> onRequest(RequestContext context, String id) async {
   }
 
   // Get the users posts.
-  final feed = await bluesky.feeds.findFeed(actor: user.did, limit: 40);
+  final feed = await bluesky.feed.getAuthorFeed(actor: user.did, limit: 40);
 
   // Take all the posts and convert them to MastodonPost futures
   // Await all the futures, getting any necessary data from the database.

--- a/routes/api/v1/accounts/[id]/unfollow.dart
+++ b/routes/api/v1/accounts/[id]/unfollow.dart
@@ -36,14 +36,14 @@ Future<Response> onRequest<T>(RequestContext context, String id) async {
   final did = record?.did;
   if (did == null) Response(statusCode: HttpStatus.notFound);
 
-  final profile = await bluesky.actors.findProfile(actor: did!);
+  final profile = await bluesky.actor.getProfile(actor: did!);
 
   // Check if we are actually following the account and get the follow uri
   // so we can delete it. Otherwise we just skip this step and return
   // the relationship.
   final followUri = profile.data.viewer.following;
   if (followUri != null) {
-    await bluesky.repositories.deleteRecord(uri: followUri);
+    await bluesky.repo.deleteRecord(uri: followUri);
   }
 
   final rel = await MastodonRelationship.getActorRelationship(bluesky, record!);

--- a/routes/api/v1/accounts/lookup.dart
+++ b/routes/api/v1/accounts/lookup.dart
@@ -18,7 +18,7 @@ Future<Response> onRequest(RequestContext context) async {
   if (bluesky == null) return authError();
 
   // Get the profile for the given handle.
-  final profile = await bluesky.actors.findProfile(actor: encodedParams.acct);
+  final profile = await bluesky.actor.getProfile(actor: encodedParams.acct);
   final account = await databaseTransaction(
     () => MastodonAccount.fromActorProfile(profile.data),
   );

--- a/routes/api/v1/accounts/search.dart
+++ b/routes/api/v1/accounts/search.dart
@@ -31,7 +31,7 @@ Future<Response> onRequest(RequestContext context) async {
       );
 
       final handle = encodedParams.query.replaceFirst('@$base', '');
-      profile = (await bluesky.actors.findProfile(actor: handle)).data;
+      profile = (await bluesky.actor.getProfile(actor: handle)).data;
     } catch (e) {
       // We just assume no account exists for now.
       print('Could not find profile with handle: ${encodedParams.query}');
@@ -47,7 +47,7 @@ Future<Response> onRequest(RequestContext context) async {
     );
   } else {
     // We assume that the query is a general search query.
-    final results = await bluesky.actors.searchActors(
+    final results = await bluesky.actor.searchActors(
       term: encodedParams.query,
       limit: encodedParams.limit,
     );
@@ -58,7 +58,7 @@ Future<Response> onRequest(RequestContext context) async {
     final profiles = await chunkResults<bsky.ActorProfile, String>(
       items: handles,
       callback: (chunk) async {
-        final response = await bluesky.actors.findProfiles(actors: chunk);
+        final response = await bluesky.actor.getProfiles(actors: chunk);
         return response.data.profiles;
       },
     );

--- a/routes/api/v1/accounts/verify_credentials.dart
+++ b/routes/api/v1/accounts/verify_credentials.dart
@@ -16,7 +16,7 @@ Future<Response> onRequest(RequestContext context) async {
   if (session == null) return authError();
   final bluesky = bsky.Bluesky.fromSession(session);
 
-  final profile = await bluesky.actors.findProfile(actor: session.did);
+  final profile = await bluesky.actor.getProfile(actor: session.did);
 
   final account = await databaseTransaction(
     () => MastodonAccount.fromActorProfile(profile.data),

--- a/routes/api/v1/lists/[id]/accounts.dart
+++ b/routes/api/v1/lists/[id]/accounts.dart
@@ -35,7 +35,7 @@ Future<Response> onRequest<T>(RequestContext context, String id) async {
   if (record == null) Response(statusCode: HttpStatus.notFound);
 
   // Get up to date profile information and convert it to a [MastodonAccount].
-  final response = await bluesky.actors.findProfile(actor: record!.did);
+  final response = await bluesky.actor.getProfile(actor: record!.did);
   final profile = await databaseTransaction(
     () => MastodonAccount.fromActorProfile(response.data),
   );

--- a/routes/api/v1/lists/index.dart
+++ b/routes/api/v1/lists/index.dart
@@ -21,7 +21,7 @@ Future<Response> onRequest(RequestContext context) async {
     var lists = <MastodonList>[];
 
     // Get saved feeds from the user's preferences.
-    final response = await bluesky.actors.findPreferences();
+    final response = await bluesky.actor.getPreferences();
     for (final preference in response.data.preferences) {
       await preference.map(
         adultContent: (_) {},
@@ -35,7 +35,7 @@ Future<Response> onRequest(RequestContext context) async {
           final result = await chunkResults<bsky.FeedGeneratorView, bsky.AtUri>(
             items: feedUris.data.savedUris,
             callback: (chunk) async {
-              final response = await bluesky.feeds.findGenerators(
+              final response = await bluesky.feed.getFeedGenerators(
                 uris: feedUris.data.savedUris,
               );
               return response.data.feeds;

--- a/routes/api/v1/notifications/index.dart
+++ b/routes/api/v1/notifications/index.dart
@@ -25,7 +25,7 @@ Future<Response> onRequest<T>(RequestContext context) async {
 
   final limit = encodedParams.limit <= 100 ? encodedParams.limit : 100;
   // Fetch the notifications with the given parameters.
-  final response = await bluesky.notifications.findNotifications(
+  final response = await bluesky.notification.listNotifications(
     limit: limit,
   );
 

--- a/routes/api/v1/statuses/[id]/context.dart
+++ b/routes/api/v1/statuses/[id]/context.dart
@@ -35,7 +35,7 @@ Future<Response> onRequest<T>(RequestContext context, String id) async {
   );
   if (postRecord == null) Response(statusCode: HttpStatus.notFound);
 
-  final posts = await bluesky.feeds.findPostThread(
+  final posts = await bluesky.feed.getPostThread(
     uri: bsky.AtUri.parse(postRecord!.uri),
   );
 

--- a/routes/api/v1/statuses/[id]/favourite.dart
+++ b/routes/api/v1/statuses/[id]/favourite.dart
@@ -39,7 +39,7 @@ Future<Response> onRequest<T>(RequestContext context, String id) async {
   // Get the post from bluesky, we assume we already know the post exists
   // and don't bother adding to the database or anything.
   final uri = bsky.AtUri.parse(postRecord!.uri);
-  final response = await bluesky.feeds.findPosts(uris: [uri]);
+  final response = await bluesky.feed.getPosts(uris: [uri]);
   final post = response.data.posts.first;
 
   // Get the user who posted this from the database.
@@ -56,7 +56,7 @@ Future<Response> onRequest<T>(RequestContext context, String id) async {
   );
 
   // Like the post now that we have everything in order.
-  await bluesky.feeds.createLike(cid: post.cid, uri: post.uri);
+  await bluesky.feed.like(cid: post.cid, uri: post.uri);
   mastodonPost
     ..favourited = true
     ..favouritesCount += 1;

--- a/routes/api/v1/statuses/[id]/favourited_by.dart
+++ b/routes/api/v1/statuses/[id]/favourited_by.dart
@@ -35,7 +35,7 @@ Future<Response> onRequest<T>(RequestContext context, String id) async {
   );
   if (postRecord == null) Response(statusCode: HttpStatus.notFound);
 
-  final response = await bluesky.feeds.findLikes(
+  final response = await bluesky.feed.getLikes(
     uri: bsky.AtUri.parse(postRecord!.uri),
   );
 
@@ -47,7 +47,7 @@ Future<Response> onRequest<T>(RequestContext context, String id) async {
   final profiles = await chunkResults<bsky.ActorProfile, String>(
     items: handles,
     callback: (chunk) async {
-      final response = await bluesky.actors.findProfiles(actors: chunk);
+      final response = await bluesky.actor.getProfiles(actors: chunk);
       return response.data.profiles;
     },
   );

--- a/routes/api/v1/statuses/[id]/reblog.dart
+++ b/routes/api/v1/statuses/[id]/reblog.dart
@@ -39,7 +39,7 @@ Future<Response> onRequest<T>(RequestContext context, String id) async {
   // Get the post from bluesky, we assume we already know the post exists
   // and don't bother adding to the database or anything.
   final uri = bsky.AtUri.parse(postRecord!.uri);
-  final response = await bluesky.feeds.findPosts(uris: [uri]);
+  final response = await bluesky.feed.getPosts(uris: [uri]);
   final post = response.data.posts.first;
 
   // Get the user who posted this from the database.

--- a/routes/api/v1/statuses/[id]/reblogged_by.dart
+++ b/routes/api/v1/statuses/[id]/reblogged_by.dart
@@ -35,7 +35,7 @@ Future<Response> onRequest<T>(RequestContext context, String id) async {
   );
   if (postRecord == null) Response(statusCode: HttpStatus.notFound);
 
-  final response = await bluesky.feeds.findRepostedBy(
+  final response = await bluesky.feed.getRepostedBy(
     uri: bsky.AtUri.parse(postRecord!.uri),
   );
 
@@ -47,7 +47,7 @@ Future<Response> onRequest<T>(RequestContext context, String id) async {
   final profiles = await chunkResults<bsky.ActorProfile, String>(
     items: handles,
     callback: (chunk) async {
-      final response = await bluesky.actors.findProfiles(actors: chunk);
+      final response = await bluesky.actor.getProfiles(actors: chunk);
       return response.data.profiles;
     },
   );

--- a/routes/api/v1/statuses/[id]/unfavourite.dart
+++ b/routes/api/v1/statuses/[id]/unfavourite.dart
@@ -39,7 +39,7 @@ Future<Response> onRequest<T>(RequestContext context, String id) async {
   // Get the post from bluesky, we assume we already know the post exists
   // and don't bother adding to the database or anything.
   final uri = bsky.AtUri.parse(postRecord!.uri);
-  final response = await bluesky.feeds.findPosts(uris: [uri]);
+  final response = await bluesky.feed.getPosts(uris: [uri]);
   final post = response.data.posts.first;
 
   // Get the user who posted this from the database.
@@ -57,7 +57,7 @@ Future<Response> onRequest<T>(RequestContext context, String id) async {
 
   if (post.viewer.like != null) {
     // Unlike the post now that we have everything in order.
-    await bluesky.repositories.deleteRecord(uri: post.viewer.like!);
+    await bluesky.repo.deleteRecord(uri: post.viewer.like!);
     mastodonPost
       ..favourited = false
       ..favouritesCount -= 1;

--- a/routes/api/v1/statuses/[id]/unreblog.dart
+++ b/routes/api/v1/statuses/[id]/unreblog.dart
@@ -39,7 +39,7 @@ Future<Response> onRequest<T>(RequestContext context, String id) async {
   // Get the post from bluesky, we assume we already know the post exists
   // and don't bother adding to the database or anything.
   final uri = bsky.AtUri.parse(postRecord!.uri);
-  final response = await bluesky.feeds.findPosts(uris: [uri]);
+  final response = await bluesky.feed.getPosts(uris: [uri]);
   final post = response.data.posts.first;
 
   // Get the user who posted this from the database.
@@ -57,7 +57,7 @@ Future<Response> onRequest<T>(RequestContext context, String id) async {
 
   if (post.viewer.repost != null) {
     // Unlike the post now that we have everything in order.
-    await bluesky.repositories.deleteRecord(uri: post.viewer.repost!);
+    await bluesky.repo.deleteRecord(uri: post.viewer.repost!);
     mastodonPost
       ..reblogged = false
       ..reblogsCount -= 1;

--- a/routes/api/v1/statuses/index.dart
+++ b/routes/api/v1/statuses/index.dart
@@ -48,7 +48,7 @@ Future<Response> onRequest<T>(RequestContext context) async {
     if (record == null) return Response(statusCode: HttpStatus.notFound);
 
     final uri = bsky.AtUri.parse(record.uri);
-    final post = (await bluesky.feeds.findPosts(uris: [uri])).data.posts.first;
+    final post = (await bluesky.feed.getPosts(uris: [uri])).data.posts.first;
 
     final parentRef = bsky.StrongRef(
       cid: post.cid,
@@ -94,14 +94,16 @@ Future<Response> onRequest<T>(RequestContext context) async {
   }
 
   // Construct an embed if we have any images to attach.
-  final embed = images.isEmpty ? null : bsky.Embed.images(
-    data: bsky.EmbedImages(
-      images: images,
-    ),
-  );
+  final embed = images.isEmpty
+      ? null
+      : bsky.Embed.images(
+          data: bsky.EmbedImages(
+            images: images,
+          ),
+        );
 
   // Create a new post with attached entities.
-  final newPost = await bluesky.feeds.createPost(
+  final newPost = await bluesky.feed.post(
     text: form.status?.value ?? '',
     facets: facets.map(bsky.Facet.fromJson).toList(),
     reply: postReplyRef,
@@ -109,7 +111,7 @@ Future<Response> onRequest<T>(RequestContext context) async {
   );
 
   // Get our newly created post.
-  final response = await bluesky.feeds.findPosts(uris: [newPost.data.uri]);
+  final response = await bluesky.feed.getPosts(uris: [newPost.data.uri]);
   final postData = response.data.posts.first;
 
   // Construct and return the new post as a [MastodonPost].

--- a/routes/api/v1/timelines/home.dart
+++ b/routes/api/v1/timelines/home.dart
@@ -35,7 +35,7 @@ Future<Response> onRequest(RequestContext context) async {
     var done = false;
 
     while (!done) {
-      final feed = await bluesky.feeds.findTimeline(
+      final feed = await bluesky.feed.getTimeline(
         limit: 100,
         cursor: prevCursor,
       );
@@ -75,7 +75,7 @@ Future<Response> onRequest(RequestContext context) async {
     nextCursor = prevCursor;
   } else {
     // Make a single, standard request
-    final feed = await bluesky.feeds.findTimeline(
+    final feed = await bluesky.feed.getTimeline(
       limit: encodedParams.limit,
       cursor: encodedParams.cursor,
     );

--- a/routes/api/v1/timelines/list/[id].dart
+++ b/routes/api/v1/timelines/list/[id].dart
@@ -35,7 +35,7 @@ Future<Response> onRequest<T>(RequestContext context, String id) async {
   );
   if (record == null) return Response(statusCode: HttpStatus.notFound);
 
-  final feed = await bluesky.feeds.findCustomFeed(
+  final feed = await bluesky.feed.getFeed(
     generatorUri: bsky.AtUri.parse(record.uri),
   );
 

--- a/routes/api/v1/trends/statuses.dart
+++ b/routes/api/v1/trends/statuses.dart
@@ -16,7 +16,7 @@ Future<Response> onRequest(RequestContext context) async {
   // Get the popular feed, this could break in the future since it's
   // not part of the spec and the bluesky devs intend to switch to a
   // way of picking your own algorithm.
-  final feed = await bluesky.unspecced.findPopularFeed(limit: 40);
+  final feed = await bluesky.unspecced.getPopular(limit: 40);
 
   // Take all the posts and convert them to Mastodon ones
   // Await all the futures, getting any necessary data from the database.

--- a/routes/api/v2/media.dart
+++ b/routes/api/v2/media.dart
@@ -85,7 +85,7 @@ Future<Response> onRequest(RequestContext context) async {
     }
 
     // Upload the image file to bluesky.
-    final response = await bluesky.repositories.uploadBlob(imageFileBytes);
+    final response = await bluesky.repo.uploadBlob(imageFileBytes);
     final blob = response.data.blob;
 
     // We need to store the blob info in the database so it can be retrieved

--- a/routes/api/v2/search.dart
+++ b/routes/api/v2/search.dart
@@ -30,7 +30,6 @@ Future<Response> onRequest<T>(RequestContext context) async {
   if (params.limit == 1 &&
       params.resolve == true &&
       params.type == SearchType.statuses) {
-
     // If the query is attempting to find a quote post, Ivory will send
     // a query with the SkyBridge instance URI in the query in a format
     // that Mastodon uses.
@@ -60,7 +59,7 @@ Future<Response> onRequest<T>(RequestContext context) async {
       // Get the post from bluesky, we assume we already know the post exists
       // and don't bother adding to the database or anything.
       final uri = bsky.AtUri.parse(postRecord!.uri);
-      final response = await bluesky.feeds.findPosts(uris: [uri]);
+      final response = await bluesky.feed.getPosts(uris: [uri]);
       final post = response.data.posts.first;
 
       final mastodonPost = await databaseTransaction(
@@ -82,12 +81,12 @@ Future<Response> onRequest<T>(RequestContext context) async {
     // Check if the query is an attempted repost to a different account.
     if (repostHandle != null && repostPostId != null) {
       // We resolve the DID and try and find the post directly from bluesky.
-      final did = await bluesky.identities.findDID(handle: repostHandle);
+      final did = await bluesky.identity.resolveHandle(handle: repostHandle);
       final uri = bsky.AtUri.parse(
         'at://${did.data.did}/app.bsky.feed.post/$repostPostId',
       );
 
-      final response = await bluesky.feeds.findPosts(uris: [uri]);
+      final response = await bluesky.feed.getPosts(uris: [uri]);
       final post = response.data.posts.first;
 
       final mastodonPost = await databaseTransaction(


### PR DESCRIPTION
Hi!

I changed method names of `atproto` and `bluesky` to Lexicon IDs. And this is a PR to replace all deprecated methods with new methods