### PR TITLE
Allow using IPv4

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,6 @@ SKYBRIDGE_SHOW_INDEX = false
 
 # Allow backfilling/scrolling on timelines? (can be cause issues on instances under heavy load)
 SKYBRIDGE_ALLOW_BACKFILL = true
+
+# Allow using IPv4 instead of IPv6
+USE_IPV4 = false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       - SKYBRIDGE_SHOW_INDEX=false
       # Allow backfilling/scrolling on timelines? (can cause issues on instances under heavy load)
       - SKYBRIDGE_ALLOW_BACKFILL=true
+      # Allow using IPv4 instead of IPv6
+      - USE_IPV4 = false
 
 volumes:
   skybridge:

--- a/server/server.dart
+++ b/server/server.dart
@@ -49,7 +49,8 @@ import '../routes/.well-known/nodeinfo.dart' as well_known_nodeinfo;
 import '../routes/_middleware.dart' as middleware;
 
 void main() async {
-  final address = InternetAddress.anyIPv6;
+  var useIPv4 = Platform.environment['USE_IPV4']?? 'false';
+  final address = useIPv4.toLowerCase() == false ? InternetAddress.anyIPv6 : InternetAddress.anyIPv4;
   final port = int.parse(Platform.environment['PORT'] ?? '8080');
   await entrypoint.init(address, port);
   createServer(address, port);


### PR DESCRIPTION
Currently the docker image fails to start if it's on a host with IPv6 disabled.

This adds in a env parameter that defaults to `false` but enables the server to use IPv4 when set to `true`